### PR TITLE
make buttons work

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ extern crate rustbox;
 extern crate time;
 extern crate unicode_width;
 extern crate unicode_segmentation;
-use time::Duration;
+use std::time::Duration;
 use rustbox::{
     RustBox,
     InputMode,
@@ -30,8 +30,8 @@ pub fn run<W: Widget>(mut widget: W) {
         rb.present();
 
         //match rb.poll_event(false) {
-        match rb.peek_event(Duration::milliseconds(100), false) {
-            Ok(Event::KeyEvent(Some(Key::Esc))) => break,
+        match rb.peek_event(Duration::from_millis(100), false) {
+            Ok(Event::KeyEvent(Key::Esc)) => break,
             Ok(ref event) => {
                 widget.handle_event(event);
             }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,7 +4,7 @@ use rustbox::{
 };
 
 pub trait Drawable {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize);
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize);
     fn width(&self) -> usize;
     fn height(&self) -> usize;
 }

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -16,7 +16,9 @@ use ::traits::{
 };
 use ::widgets::{Base, Label};
 
-pub type Action = ();
+pub enum Action {
+    Clicked,
+}
 
 pub struct Button<M> {
     base: Rc<Base<Button<M>, M, Action>>,
@@ -71,10 +73,11 @@ impl <M> Button<M> {
 }
 
 impl <M> Drawable for Button<M> {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
         if width == 0 || height == 0 { return }
         let height = height - 1; // Because drawing at `height + width` is off by one
-
+        self.x = x as i32;
+        self.y = y as i32;
         let width = self.label.width();
         let clicked = match self.clicked {
             true => RB_REVERSE,
@@ -122,11 +125,16 @@ impl <M> EventReceiver for Button<M> {
             Event::MouseEvent(Mouse::Left, x, y) => {
                 let width = self.width() as i32;
                 let height = self.height() as i32;
-                if x >= self.x && y >= self.y
-                    && x < self.x + width
-                    && y < self.y + height
+                let pos_x = self.x;
+                let pos_y = self.y;
+
+                if x >= pos_x && y >= pos_y
+                    && x < pos_x + width
+                    && y < pos_y + height
                 {
-                    self.toggle();
+                    if !self.clicked {
+                        self.toggle();
+                    }
                     true
                 } else {
                     true

--- a/src/widgets/checkbox.rs
+++ b/src/widgets/checkbox.rs
@@ -54,7 +54,7 @@ impl <M> Checkbox<M> {
 }
 
 impl <M> Drawable for Checkbox<M> {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, _width: usize, _height: usize) {
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, _width: usize, _height: usize) {
         let ch = match self.checked {
             true => '☒',
             false => '☐'

--- a/src/widgets/checkbox.rs
+++ b/src/widgets/checkbox.rs
@@ -73,7 +73,7 @@ impl <M> Drawable for Checkbox<M> {
 
 impl <M> EventReceiver for Checkbox<M> {
     fn handle_event(&mut self, event: &Event) -> bool {
-        if let Event::KeyEvent(Some(Key::Char(' '))) = *event {
+        if let Event::KeyEvent(Key::Char(' ')) = *event {
             self.do_action(match self.checked {
                 true => Action::Check,
                 false => Action::Uncheck

--- a/src/widgets/frame.rs
+++ b/src/widgets/frame.rs
@@ -80,7 +80,7 @@ impl <M> Frame<M> {
 }
 
 impl <M> Drawable for Frame<M> {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
         if width <= 3 || height <= 3 { return }
 
         let print = |x, y, ch| rb.print_char(x, y, RB_NORMAL, Color::Default, Color::Default, ch);
@@ -106,7 +106,7 @@ impl <M> Drawable for Frame<M> {
         print(x + width - 1, y + height - 1, shadow);
 
         // Render child
-        if let Some(ref child) = self.child {
+        if let Some(ref mut child) = self.child {
             // Don't render child if too frame small
             let border_size = 3;
             if width < border_size || height < border_size { return }

--- a/src/widgets/horizontal_layout.rs
+++ b/src/widgets/horizontal_layout.rs
@@ -51,9 +51,9 @@ impl <M> HorizontalLayout<M> {
 }
 
 impl <M> Drawable for HorizontalLayout<M> {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
         let mut x_offset = 0;
-        for child in self.children.iter() {
+        for child in self.children.iter_mut() {
             let remaining_width = if x_offset < width {
                 width - x_offset
             } else {

--- a/src/widgets/input.rs
+++ b/src/widgets/input.rs
@@ -80,18 +80,18 @@ impl <M> Drawable for Input<M> {
 impl <M> EventReceiver for Input<M> {
     fn handle_event(&mut self, _event: &Event) -> bool {
         match *_event {
-            Event::KeyEvent(Some(Key::Enter)) => {
+            Event::KeyEvent(Key::Enter) => {
                 let curr_text = self.text.clone();
                 self.do_action(Action::Submitted(curr_text));
                 true
             },
-            Event::KeyEvent(Some(Key::Backspace)) => {
+            Event::KeyEvent(Key::Backspace) => {
                 self.text.pop();
                 let curr_text = self.text.clone();
                 self.do_action(Action::TextChanged(curr_text));
                 true
             },
-            Event::KeyEvent(Some(Key::Char(key))) => {
+            Event::KeyEvent(Key::Char(key)) => {
                 self.text = self.text.clone() + &key.to_string();
                 let curr_text = self.text.clone();
                 self.do_action(Action::TextChanged(curr_text));

--- a/src/widgets/input.rs
+++ b/src/widgets/input.rs
@@ -62,7 +62,7 @@ impl <M> Input<M> {
 }
 
 impl <M> Drawable for Input<M> {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, _width: usize, _height: usize) {
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, _width: usize, _height: usize) {
         let title_width = self.title().width();
         rb.print(x, y, RB_NORMAL, Color::Default, Color::Default, &self.title);
         rb.print(x + title_width, y, RB_REVERSE, Color::Default, Color::Default, &self.text);

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -52,7 +52,7 @@ impl <M> Label<M> {
 }
 
 impl <M> Drawable for Label<M> {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
         if width == 0 || height == 0 { return };
         let mut x = x;
         let mut remaining_width = width;

--- a/src/widgets/progress.rs
+++ b/src/widgets/progress.rs
@@ -60,7 +60,7 @@ impl <M> Progress<M> {
 }
 
 impl <M> Drawable for Progress<M> {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, _width: usize, _height: usize) {
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, _width: usize, _height: usize) {
         //rb.print(0, 0, RB_NORMAL, )
         fn get_sym(n: i64) -> char{
             match n {

--- a/src/widgets/spinner.rs
+++ b/src/widgets/spinner.rs
@@ -81,7 +81,7 @@ impl <M> Spinner<M> {
 }
 
 impl <M> Drawable for Spinner<M> {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, _width: usize, _height: usize) {
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, _width: usize, _height: usize) {
         let ch = self.get_anim_char();
         let color = self.get_anim_color();
         self.increment_frame();

--- a/src/widgets/vertical_layout.rs
+++ b/src/widgets/vertical_layout.rs
@@ -51,9 +51,9 @@ impl <M> VerticalLayout<M> {
 }
 
 impl <M> Drawable for VerticalLayout<M> {
-    fn draw_at(&self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
+    fn draw_at(&mut self, rb: &RustBox, x: usize, y: usize, width: usize, height: usize) {
         let mut y_offset = 0;
-        for child in self.children.iter() {
+        for child in self.children.iter_mut() {
             let remaining_height = if y_offset < height {
                 height - y_offset
             } else {


### PR DESCRIPTION
To get this to work I had to adjust the the `Drawable` trait to allow for `&mut self` so that the callee could mutate it's `x` and `y` values based on what the frame or layout was setting it to. This made sure the x and y values were set correctly for the instance so they could be checked properly against the mouse location. Kind of gross but it works. Couldn't think of a cleaner way to do it, but I'd be willing to give another idea a try.
